### PR TITLE
Fix compile process by linking with -lrt

### DIFF
--- a/ether/Makefile
+++ b/ether/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 CFLAGS+=
-LDFLAGS+=
+LDFLAGS+=-lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9]
 FILES=Makefile *.mak *.sh *.c *.h 
 TOOLS=efbu efeu efru efsu edru edsu nics 

--- a/nvm/Makefile
+++ b/nvm/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 CFLAGS+=
-LDFLAGS+=
+LDFLAGS+=-lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9] *.test *-[0-9][0-9].nvm
 FILES=Makefile *.mak *.sh *.txt *.c *.h *.xml *.css
 TOOLS=chknvm chknvm2 nvmsplit nvmmerge

--- a/pib/Makefile
+++ b/pib/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 CFLAGS+=
-LDFLAGS+=-lm
+LDFLAGS+=-lm -lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9] *.test 
 FILES=Makefile *.mak *.sh *.txt *.c *.h *.xml *.css
 TOOLS=chkpib chkpib2 setpib getpib modpib pib2xml pibcomp pibdump pibruin xml2pib psin psout pskey

--- a/plc/Makefile
+++ b/plc/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 CFLAGS+=-DAR7x00 
-LDFLAGS+=
+LDFLAGS+=-lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9]
 FILES=Makefile *.mak *.sh *.txt *.c
 TOOLS=int6k int6kboot int6keth int6kf int6khost int64host int6kid int6klist int6klog int6kmdio int6kmdio2 int6kmod int6kstat int6ktest int6krate int6krule int6ktone int6kwait CMEncrypt sada coqos_add coqos_info coqos_man coqos_mod coqos_rel mdustats

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 CFLAGS+=
-LDFLAGS+=
+LDFLAGS+=-lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9]
 FILES=Makefile *.mak *.sh *.txt *.c *.h 
 TOOLS=int6kuart int6kbaud ttysig ptsctl weeder ttysend ttyrecv ttycat int6kdetect 

--- a/slac/Makefile
+++ b/slac/Makefile
@@ -12,7 +12,7 @@ include ../make.def
 # --------------------------------------------------------------------
 
 # CFLAGS+= -DSLAC_DEBUG
-LDFLAGS+=-lm
+LDFLAGS+=-lm -lrt
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9] 
 FILES=Makefile *.mak *.sh *.c *.h 
 TOOLS=evse pev


### PR DESCRIPTION
According to the man page 'man clock_gettime', we need to link
with -lrt for glibc versions before 2.17.

This fixes the following error (and similar ones) during the
compilation process:
getmonotonictime.c:(.text+0x15): undefined reference to `clock_gettime'

Signed-off-by: Michael Heimpold michael.heimpold@i2se.com
